### PR TITLE
Fix: Close notify all consumers

### DIFF
--- a/include/msd/channel.hpp
+++ b/include/msd/channel.hpp
@@ -116,7 +116,6 @@ class channel {
     const size_type cap;
     std::queue<T> queue;
     std::mutex mtx;
-    std::mutex rmtx;
     std::condition_variable cnd;
     std::atomic<bool> is_closed;
 

--- a/include/msd/channel.hpp
+++ b/include/msd/channel.hpp
@@ -116,6 +116,7 @@ class channel {
     const size_type cap;
     std::queue<T> queue;
     std::mutex mtx;
+    std::mutex rmtx;
     std::condition_variable cnd;
     std::atomic<bool> is_closed;
 

--- a/include/msd/channel_impl.hpp
+++ b/include/msd/channel_impl.hpp
@@ -51,10 +51,12 @@ void operator<<(T& out, channel<T>& ch)
     }
 
     ch.waitBeforeRead();
-
-    if (ch.queue.size() > 0) {
-        out = std::move(ch.queue.front());
-        ch.queue.pop();
+    {
+        std::unique_lock<std::mutex> lock{ch.rmtx};
+        if (ch.queue.size() > 0) {
+            out = std::move(ch.queue.front());
+            ch.queue.pop();
+        }
     }
     ch.cnd.notify_one();
 }

--- a/include/msd/channel_impl.hpp
+++ b/include/msd/channel_impl.hpp
@@ -52,7 +52,7 @@ void operator<<(T& out, channel<T>& ch)
 
     ch.waitBeforeRead();
     {
-        std::unique_lock<std::mutex> lock{ch.rmtx};
+        std::unique_lock<std::mutex> lock{ch.mtx};
         if (ch.queue.size() > 0) {
             out = std::move(ch.queue.front());
             ch.queue.pop();

--- a/include/msd/channel_impl.hpp
+++ b/include/msd/channel_impl.hpp
@@ -74,8 +74,8 @@ constexpr bool channel<T>::empty() const noexcept
 template <typename T>
 void channel<T>::close() noexcept
 {
-    cnd.notify_all();
     is_closed.store(true);
+    cnd.notify_all();
 }
 
 template <typename T>

--- a/include/msd/channel_impl.hpp
+++ b/include/msd/channel_impl.hpp
@@ -74,7 +74,7 @@ constexpr bool channel<T>::empty() const noexcept
 template <typename T>
 void channel<T>::close() noexcept
 {
-    cnd.notify_one();
+    cnd.notify_all();
     is_closed.store(true);
 }
 


### PR DESCRIPTION
Hi,

we have multiple consumers listening on the same channel. When the channel is closed only one consumer is notified. This PR addresses this issue by notifying all listening threads on `close()`.

