### PR TITLE
Minor fix

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,7 @@ jobs:
         # Note the current convention is to use the -S and -B options here to specify source
         # and build directories, but this is only available with CMake 3.13 and higher.
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -Dcpp_channel_build_examples=ON -Dcpp_channel_build_tests=ON
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 cmake_minimum_required(VERSION 3.12)
 project(cpp_channel)
 set(PROJECT_VERSION 0.7.2)
@@ -14,7 +15,14 @@ include_directories(include)
 add_library(msd_channel INTERFACE)
 target_include_directories(msd_channel INTERFACE include)
 
-enable_testing()
-add_subdirectory(tests)
+option(cpp_channel_build_tests "Build all of cpp_channel's own tests." OFF)
+option(cpp_channel_build_examples "Build cpp_channel's example programs." OFF)
 
-add_subdirectory(examples)
+if (cpp_channel_build_tests)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+if (cpp_channel_build_examples)
+    add_subdirectory(examples)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 3.12)
 project(cpp_channel)
 set(PROJECT_VERSION 0.7.2)

--- a/examples/close.cpp
+++ b/examples/close.cpp
@@ -1,5 +1,6 @@
 #include <future>
 #include <iostream>
+#include <thread>
 
 #include "msd/channel.hpp"
 


### PR DESCRIPTION
Hi, the library is great, thanks!

I ran into some trivial problems when including this library, in my CMakeLists.txt I have the following statements:

```cmake
include(FetchContent)
FetchContent_Declare(
  channel
  URL https://github.com/andreiavrammsd/cpp-channel/archive/refs/tags/v0.7.2.zip
)
FetchContent_MakeAvailable(channel)
include_directories(${channel_SOURCE_DIR}/include)
```
I noticed using `FetchContent_MakeAvailable` instead of `FetchContent_Populate` as in [the example CMakeLists](https://github.com/andreiavrammsd/cpp-channel/blob/master/examples/cmake-project/CMakeLists.txt) will give way to building tests and examples, which blocked the cmake for downloading and building googletest and generated a lot of binaries irrelevant to my project

So I wonder if it's appropriate to add some conditionals to CMakeLists.txt to control the building process, this PR will turn off the examples and tests building in default mode.  After that, if the library users happen to use `FetchContent_MakeAvailable` incidentally, they won't have to build the tests and examples by default.  The test is slow to initialize in regions with poor networks.

To enable them, we can run the following command:

```shell
cmake -Dcpp_channel_build_examples=ON -Dcpp_channel_build_tests=ON -Bbuild -H.
```

Also, when building my project with this library for the first time, I noticed the example code has an include problem, I am not using any IDE, so perhaps this is caused by IDEs?

Best regards!



