### PR TITLE
fix: race condition in close #37

### DIFF
--- a/include/msd/channel.inl
+++ b/include/msd/channel.inl
@@ -65,7 +65,10 @@ constexpr bool channel<T>::empty() const noexcept
 template <typename T>
 void channel<T>::close() noexcept
 {
-    is_closed_.store(true);
+    {
+        std::unique_lock<std::mutex> lock{mtx_};
+        is_closed_.store(true);
+    }
     cnd_.notify_all();
 }
 


### PR DESCRIPTION
Because the close method does not lock and the read method does not check the closed value after locking, it's possible for a deadlock to occur under the following series of events:

Thread 1 (reader): read last element from the channel
Thread 1: call operator>>
Thread 1: check closed(), which is false
Thread 1: lock mutex
Thread 1: check the predicate in wait()
Thread 2 (writer): call close()
Thread 2: set closed=true
Thread 2: call cnd_.notify_all()
Thread 1: calls wait() without predicate (in the implementation of the wait with predicate method)

At this point, Thread 1 waits forever because the notify_all occurred before the actual call to wait().

I don't have a good minimal test case for the issue here, but I have run it for several hours in a loop an integration test that was deadlocking before, so I'm fairly confident the issue is fixed.