### PR TITLE
[New Feature] Timeout-capable channels

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,6 +46,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        
+      - name: Install GCC 12
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-12 g++-12 cmake
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
+          gcc --version
+          g++ --version
 
       - name: Create Build Environment
         # Some projects don't allow in-source building, so create a separate build directory

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * Blocking (forever waiting to fetch).
 * Range-based for loop supported.
 * Close to prevent pushing and stop waiting to fetch.
+* Optional timeout for read/write operations using `std::chrono`.
 * Integrates well with STL algorithms in some cases. Eg: std::move(ch.begin(), ch.end(), ...).
 * Tested with GCC, Clang, and MSVC.
 
@@ -29,7 +30,6 @@ see [CMakeLists.txt](./examples/cmake-project/CMakeLists.txt) from the [CMake pr
 
 ```c++
 #include <cassert>
-
 #include <msd/channel.hpp>
 
 int main() {
@@ -83,7 +83,6 @@ int main() {
 
 ```c++
 #include <iostream>
-
 #include <msd/channel.hpp>
 
 int main() {
@@ -98,6 +97,31 @@ int main() {
         std::cout << out << '\n';
     }
 }
+```
+
+````c++
+#include <iostream>
+#include <msd/channel.hpp>
+
+int main() {
+    msd::channel<int> ch{2};
+    ch.setTimeout(std::chrono::milliseconds(100));
+
+    std::clog << "Testing write timeout on full buffer:\n";
+    try {
+        ch << 1;
+        ch << 2;
+        std::clog << "Attempting to write to full channel...\n";
+        ch << 3;
+    }
+    catch (const msd::channel_timeout& e) {
+        std::clog << "Expected timeout occurred: " << e.what() << "\n";
+    }
+
+    return 0;
+}
+
+
 ```
 
 See [examples](examples).

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ int main() {
 }
 ```
 
-````c++
+```c++
 #include <iostream>
 #include <msd/channel.hpp>
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -36,3 +36,6 @@ add_example(example_multithreading multithreading.cpp)
 
 add_example(example_streaming streaming.cpp)
 run_example(example_streaming)
+
+add_example(example_timeout timeout.cpp)
+run_example(example_timeout)

--- a/examples/timeout.cpp
+++ b/examples/timeout.cpp
@@ -1,0 +1,125 @@
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include "msd/channel.hpp"
+
+// using namespace std::chrono_literals; for post-C++11 code, use this to save some headaches
+
+void demonstrateTimeouts()
+{
+    // small capacity, short timeout
+    msd::channel<int> ch{2};
+    ch.setTimeout(std::chrono::milliseconds(100));
+
+    std::cout << "Testing write timeout on full buffer:\n";
+    try {
+        ch << 1;
+        ch << 2;
+        std::cout << "Attempting to write to full channel...\n";
+        ch << 3;
+    }
+    catch (const msd::channel_timeout& e) {
+        std::cout << "Expected timeout occurred: " << e.what() << "\n";
+    }
+
+    std::cout << "\nTesting read timeout on empty channel:\n";
+
+    msd::channel<int> ch2{5};
+    ch2.setTimeout(std::chrono::milliseconds(200));
+
+    try {
+        int value;
+        std::cout << "Attempting to read from empty channel...\n";
+        ch2 >> value;
+    }
+    catch (const msd::channel_timeout& e) {
+        std::cout << "Expected timeout occurred: " << e.what() << "\n";
+    }
+
+    std::cout << "\nDemonstrating timeout with range-based for loop:\n";
+
+    msd::channel<int> ch3{5};
+    ch3.setTimeout(std::chrono::milliseconds(200));  // lower this to see the timeout
+
+    // Producer
+    std::thread writer([&ch3]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        ch3 << 1;
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        ch3 << 2;
+        ch3.close();
+    });
+
+    // Consumer
+    try {
+        for (const auto& value : ch3) {
+            std::cout << "Received value: " << value << "\n";
+        }
+    }
+    catch (const msd::channel_timeout& e) {
+        std::cout << "Timeout in for loop: " << e.what() << "\n";
+    }
+
+    writer.join();
+}
+
+int main()
+{
+    // small capacity, short timeout
+    msd::channel<int> ch{2};
+    ch.setTimeout(std::chrono::milliseconds(100));
+
+    std::cout << "Testing write timeout on full buffer:\n";
+    try {
+        ch << 1;
+        ch << 2;
+        std::cout << "Attempting to write to full channel...\n";
+        ch << 3;
+    }
+    catch (const msd::channel_timeout& e) {
+        std::cout << "Expected timeout occurred: " << e.what() << "\n";
+    }
+
+    std::cout << "\nTesting read timeout on empty channel:\n";
+
+    msd::channel<int> ch2{5};
+    ch2.setTimeout(std::chrono::milliseconds(200));
+
+    try {
+        int value;
+        std::cout << "Attempting to read from empty channel...\n";
+        ch2 >> value;
+    }
+    catch (const msd::channel_timeout& e) {
+        std::cout << "Expected timeout occurred: " << e.what() << "\n";
+    }
+
+    std::cout << "\nDemonstrating timeout with range-based for loop:\n";
+
+    msd::channel<int> ch3{5};
+    ch3.setTimeout(std::chrono::milliseconds(200));  // lower this to see the timeout
+
+    // Producer
+    std::thread writer([&ch3]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        ch3 << 1;
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        ch3 << 2;
+        ch3.close();
+    });
+
+    // Consumer
+    try {
+        for (const auto& value : ch3) {
+            std::cout << "Received value: " << value << "\n";
+        }
+    }
+    catch (const msd::channel_timeout& e) {
+        std::cout << "Timeout in for loop: " << e.what() << "\n";
+    }
+
+    writer.join();
+
+    return 0;
+}

--- a/examples/timeout.cpp
+++ b/examples/timeout.cpp
@@ -6,64 +6,6 @@
 
 // using namespace std::chrono_literals; for post-C++11 code, use this to save some headaches
 
-void demonstrateTimeouts()
-{
-    // small capacity, short timeout
-    msd::channel<int> ch{2};
-    ch.setTimeout(std::chrono::milliseconds(100));
-
-    std::cout << "Testing write timeout on full buffer:\n";
-    try {
-        ch << 1;
-        ch << 2;
-        std::cout << "Attempting to write to full channel...\n";
-        ch << 3;
-    }
-    catch (const msd::channel_timeout& e) {
-        std::cout << "Expected timeout occurred: " << e.what() << "\n";
-    }
-
-    std::cout << "\nTesting read timeout on empty channel:\n";
-
-    msd::channel<int> ch2{5};
-    ch2.setTimeout(std::chrono::milliseconds(200));
-
-    try {
-        int value;
-        std::cout << "Attempting to read from empty channel...\n";
-        ch2 >> value;
-    }
-    catch (const msd::channel_timeout& e) {
-        std::cout << "Expected timeout occurred: " << e.what() << "\n";
-    }
-
-    std::cout << "\nDemonstrating timeout with range-based for loop:\n";
-
-    msd::channel<int> ch3{5};
-    ch3.setTimeout(std::chrono::milliseconds(200));  // lower this to see the timeout
-
-    // Producer
-    std::thread writer([&ch3]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-        ch3 << 1;
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-        ch3 << 2;
-        ch3.close();
-    });
-
-    // Consumer
-    try {
-        for (const auto& value : ch3) {
-            std::cout << "Received value: " << value << "\n";
-        }
-    }
-    catch (const msd::channel_timeout& e) {
-        std::cout << "Timeout in for loop: " << e.what() << "\n";
-    }
-
-    writer.join();
-}
-
 int main()
 {
     // small capacity, short timeout

--- a/include/msd/channel.hpp
+++ b/include/msd/channel.hpp
@@ -149,5 +149,4 @@ class channel {
 
 }  // namespace msd
 
-#include "channel.inl"
 #endif  // MSD_CHANNEL_HPP_

--- a/include/msd/channel.hpp
+++ b/include/msd/channel.hpp
@@ -137,7 +137,7 @@ class channel {
     std::mutex mtx_;
     std::condition_variable cnd_;
     std::atomic<bool> is_closed_{false};
-    std::chrono::nanoseconds timeout_;
+    std::atomic<std::chrono::nanoseconds> timeout_{std::chrono::nanoseconds::zero()};
 
     template <typename Predicate>
     bool waitWithTimeout(std::unique_lock<std::mutex>&, Predicate);

--- a/include/msd/channel.hpp
+++ b/include/msd/channel.hpp
@@ -140,7 +140,7 @@ class channel {
     std::atomic<std::chrono::nanoseconds> timeout_{std::chrono::nanoseconds::zero()};
 
     template <typename Predicate>
-    bool waitWithTimeout(std::unique_lock<std::mutex>&, Predicate);
+    bool waitWithTimeout(std::unique_lock<std::mutex>&, Predicate&&);
     bool waitBeforeRead(std::unique_lock<std::mutex>&);
     bool waitBeforeWrite(std::unique_lock<std::mutex>&);
 

--- a/include/msd/channel.inl
+++ b/include/msd/channel.inl
@@ -23,7 +23,7 @@ template <typename T>
 template <typename Predicate>
 bool channel<T>::waitWithTimeout(std::unique_lock<std::mutex>& lock, Predicate pred)
 {
-    if (!timeout_.load().count()) [[likely]] {
+    if (!timeout_.load().count()) {
         cnd_.wait(lock, pred);
         return true;
     }
@@ -49,7 +49,7 @@ bool channel<T>::waitBeforeWrite(std::unique_lock<std::mutex>& lock)
 template <typename T>
 channel<typename std::decay<T>::type>& operator<<(channel<typename std::decay<T>::type>& ch, T&& in)
 {
-    if (ch.closed()) [[unlikely]] {
+    if (ch.closed()) {
         throw closed_channel{"cannot write on closed channel"};
     }
     {
@@ -67,7 +67,7 @@ channel<typename std::decay<T>::type>& operator<<(channel<typename std::decay<T>
 template <typename T>
 channel<T>& operator>>(channel<T>& ch, T& out)
 {
-    if (ch.closed() && ch.empty()) [[unlikely]] {
+    if (ch.closed() && ch.empty()) {
         return ch;
     }
     {

--- a/include/msd/channel.inl
+++ b/include/msd/channel.inl
@@ -21,15 +21,15 @@ void channel<T>::clearTimeout() noexcept
 
 template <typename T>
 template <typename Predicate>
-bool channel<T>::waitWithTimeout(std::unique_lock<std::mutex>& lock, Predicate pred)
+bool channel<T>::waitWithTimeout(std::unique_lock<std::mutex>& lock, Predicate&& predicate)
 {
     auto timeout = timeout_.load(std::memory_order_relaxed);
     if (timeout == std::chrono::nanoseconds::zero()) {
-        cnd_.wait(lock, pred);
+        cnd_.wait(lock, std::forward<Predicate>(pred));
         return true;
     }
 
-    return cnd_.wait_for(lock, timeout, pred);
+    return cnd_.wait_for(lock, timeout, std::forward<Predicate>(pred));
 }
 
 template <typename T>

--- a/include/msd/channel.inl
+++ b/include/msd/channel.inl
@@ -25,11 +25,11 @@ bool channel<T>::waitWithTimeout(std::unique_lock<std::mutex>& lock, Predicate&&
 {
     auto timeout = timeout_.load(std::memory_order_relaxed);
     if (timeout == std::chrono::nanoseconds::zero()) {
-        cnd_.wait(lock, std::forward<Predicate>(pred));
+        cnd_.wait(lock, std::forward<Predicate>(predicate));
         return true;
     }
 
-    return cnd_.wait_for(lock, timeout, std::forward<Predicate>(pred));
+    return cnd_.wait_for(lock, timeout, std::forward<Predicate>(predicate));
 }
 
 template <typename T>

--- a/tests/channel_test.cpp
+++ b/tests/channel_test.cpp
@@ -1,3 +1,5 @@
+#include "msd/channel.hpp"
+
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -8,8 +10,6 @@
 #include <thread>
 #include <type_traits>
 #include <vector>
-
-#include "msd/channel.hpp"
 
 TEST(ChannelTest, Traits)
 {


### PR DESCRIPTION
## Features

I tried implementing my spin on #50 in the library while keeping API compatibility. 

A timeout can be set on channel `ch` like this:

```c++
ch.setTimeout(std::chrono::milliseconds(100));
```

Or, if the user is using >=C++14, in the more convenient way:

```c++
ch.setTimeout(100ms); // millis
ch.setTimeout(1s); // seconds
```

This applies a timeout on all `operator>>,operator<<` performed on the channel by using the already-existing condition variable member. if the timeout is exceeded, a `channel_timeout` exception is thrown.

The timeout can be removed by calling
```c++
ch.clearTimeout();
```

Which is just a convenient alias for `ch.setTimeout(std::chrono::nanoseconds::zero())`

The `timeout_` member is wrapped in a `std::atomic` variable to prevent hazards during multi-threaded execution in a (hopefully) lock-free manner

## Compatibility with existing code

The new header library runs all previous tests and examples successfully. New tests have been added to the `channel_test.cpp` suite to cover the new timeout functionality..

Branching on whether a timeout is present or not always costs a bit of overhead on every operation as shown in the Benchmarks section. 
Even if the library maintains 100% compatibility with previous versions, the feature provided here is not a *zero-cost abstraction*, so it is up to the maintainers to decide if its inclusion in the main repo is worth it.

## Benchmarks

The timeout code adds a 7ns fixed overhead to operations when no timeout is being used, for a performance pessimisation of around ~20% (benchmarks below run on my i5-6500 with freq scaling off, release build).

```
>>> MASTER

Run on (4 X 3299.99 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 8.98, 5.18, 4.13
---------------------------------------------------------------
Benchmark                     Time             CPU   Iterations
---------------------------------------------------------------
BM_ChannelWithInt          33.7 ns         32.8 ns     20944355
BM_ChannelWithString       38.9 ns         38.2 ns     18428982
BM_ChannelWithStruct       41.0 ns         40.7 ns     17215072

>>> TIMEOUT

Run on (4 X 3299.99 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB (x1)
Load Average: 8.16, 5.59, 4.33
---------------------------------------------------------------
Benchmark                     Time             CPU   Iterations
---------------------------------------------------------------
BM_ChannelWithInt          40.4 ns         40.2 ns     17433770
BM_ChannelWithString       45.6 ns         45.3 ns     15567840
BM_ChannelWithStruct       47.1 ns         46.9 ns     14965060
```