### PR TITLE
Output iterator

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,6 @@ Checks: >
   -readability-named-parameter,
   -altera-unroll-loops,
   -llvmlibc-inline-function-decl,
-  -cppcoreguidelines-avoid-const-or-ref-data-members,
   -cert-dcl21-cpp,
   -fuchsia-default-arguments-declarations
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,9 @@ Checks: >
   -readability-named-parameter,
   -altera-unroll-loops,
   -llvmlibc-inline-function-decl,
-  -cppcoreguidelines-avoid-const-or-ref-data-members
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cert-dcl21-cpp,
+  -fuchsia-default-arguments-declarations
 
 WarningsAsErrors: "*"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project(cpp_channel)
-set(PROJECT_VERSION 1.1.0)
+set(PROJECT_VERSION 1.2.0)
 
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard")
 set(CMAKE_CXX_STANDARD_REQUIRED YES)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Channel
 
-[![build](https://github.com/andreiavrammsd/cpp-channel/workflows/build/badge.svg)](https://github.com/andreiavrammsd/cpp-channel/actions) [![codecov](https://codecov.io/github/andreiavrammsd/cpp-channel/graph/badge.svg?token=CKQ0TVW62Z)](https://codecov.io/github/andreiavrammsd/cpp-channel)
+[![build](https://github.com/andreiavrammsd/cpp-channel/actions/workflows/cmake.yml/badge.svg)](https://github.com/andreiavrammsd/cpp-channel/actions) [![codecov](https://codecov.io/github/andreiavrammsd/cpp-channel/graph/badge.svg?token=CKQ0TVW62Z)](https://codecov.io/github/andreiavrammsd/cpp-channel)
 [![documentation](https://github.com/andreiavrammsd/cpp-channel/workflows/doc/badge.svg)](https://andreiavrammsd.github.io/cpp-channel/)
 
 ### Thread-safe container for sharing data between threads. Header-only.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Choose one of the methods:
 
 * Copy the [include](https://github.com/andreiavrammsd/cpp-channel/tree/master/include) directory into your project and add it to your include path.
 * [CMake FetchContent](https://github.com/andreiavrammsd/cpp-channel/tree/master/examples/cmake-project)
-* [CMake install](https://cmake.org/cmake/help/latest/command/install.html)
+* [CMake install](https://cmake.org/cmake/help/latest/command/install.html) - Choose a [version](https://github.com/andreiavrammsd/cpp-channel/releases), then run:
 ```shell
-VERSION=1.1.0 \
+VERSION=X.Y.Z \
     && wget https://github.com/andreiavrammsd/cpp-channel/archive/refs/tags/v$VERSION.zip \
     && unzip v$VERSION.zip \
     && cd cpp-channel-$VERSION \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 * Blocking (forever waiting to fetch).
 * Range-based for loop supported.
 * Close to prevent pushing and stop waiting to fetch.
-* Integrates well with STL algorithms in some cases. Eg: std::move(ch.begin(), ch.end(), ...).
+* Integrates well with STL algorithms in some cases. Eg:
+    * `std::move(ch.begin(), ch.end(), ...)`
+    * `std::transform(input_chan.begin(), input_chan.end(), msd::back_inserter(output_chan))`.
 * Tested with GCC, Clang, and MSVC.
 * Includes stack-based, exception-free alternative (static channel).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://github.com/andreiavrammsd/cpp-channel/actions/workflows/cmake.yml/badge.svg)](https://github.com/andreiavrammsd/cpp-channel/actions) [![codecov](https://codecov.io/github/andreiavrammsd/cpp-channel/graph/badge.svg?token=CKQ0TVW62Z)](https://codecov.io/github/andreiavrammsd/cpp-channel)
 [![documentation](https://github.com/andreiavrammsd/cpp-channel/workflows/doc/badge.svg)](https://andreiavrammsd.github.io/cpp-channel/)
 
-### Thread-safe container for sharing data between threads. Header-only.
+### Thread-safe container for sharing data between threads (synchronized queue). Header-only. Compatible with C++11.
 
 * Thread-safe push and fetch.
 * Use stream operators to push (<<) and fetch (>>) items.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,3 +39,6 @@ run_example(example_streaming)
 
 add_example(example_multithreading_static_channel multithreading_static_channel.cpp)
 run_example(example_multithreading_static_channel)
+
+add_example(example_merge_channels merge_channels.cpp)
+run_example(example_merge_channels)

--- a/include/msd/blocking_iterator.hpp
+++ b/include/msd/blocking_iterator.hpp
@@ -49,9 +49,9 @@ class blocking_iterator {
      * @param chan Reference to the channel this iterator will iterate over.
      * @param is_end If true, the iterator is in an end state (no elements to read).
      */
-    explicit blocking_iterator(Channel& chan, bool is_end = false) : chan_{chan}, is_end_{is_end}
+    explicit blocking_iterator(Channel& chan, bool is_end = false) : chan_{&chan}, is_end_{is_end}
     {
-        if (!is_end_ && !chan_.read(value_)) {
+        if (!is_end_ && !chan_->read(value_)) {
             is_end_ = true;
         }
     }
@@ -63,7 +63,7 @@ class blocking_iterator {
      */
     blocking_iterator<Channel> operator++() noexcept
     {
-        if (!chan_.read(value_)) {
+        if (!chan_->read(value_)) {
             is_end_ = true;
         }
         return *this;
@@ -87,7 +87,7 @@ class blocking_iterator {
     bool operator!=(const blocking_iterator& other) { return is_end_ != other.is_end_; }
 
    private:
-    Channel& chan_;
+    Channel* chan_;
     value_type value_{};
     bool is_end_{false};
 };
@@ -132,7 +132,7 @@ class blocking_writer_iterator {
      *
      * @param chan Reference to the channel this iterator will write into.
      */
-    explicit blocking_writer_iterator(Channel& chan) : chan_{chan} {}
+    explicit blocking_writer_iterator(Channel& chan) : chan_{&chan} {}
 
     /**
      * @brief Writes an element into the channel, blocking until space is available.
@@ -143,7 +143,7 @@ class blocking_writer_iterator {
      */
     blocking_writer_iterator& operator=(const value_type& val)
     {
-        chan_.write(val);
+        chan_->write(val);
         return *this;
     }
 
@@ -169,7 +169,7 @@ class blocking_writer_iterator {
     blocking_writer_iterator operator++(int) { return *this; }
 
    private:
-    Channel& chan_;
+    Channel* chan_;
 };
 
 /**

--- a/include/msd/blocking_iterator.hpp
+++ b/include/msd/blocking_iterator.hpp
@@ -92,6 +92,100 @@ class blocking_iterator {
     bool is_end_{false};
 };
 
+/**
+ * @brief An output iterator pushes elements into a channel. Blocking until the channel is not full.
+ *
+ * Used to integrate with standard algorithms that require an output iterator.
+ *
+ * @tparam Channel Type of channel being iterated.
+ */
+template <typename Channel>
+class blocking_writer_iterator {
+   public:
+    /**
+     * @brief The type of the elements stored in the channel.
+     */
+    using value_type = typename Channel::value_type;
+
+    /**
+     * @brief Constant reference to the type of the elements stored in the channel.
+     */
+    using reference = const value_type&;
+
+    /**
+     * @brief Supporting writing of elements.
+     */
+    using iterator_category = std::output_iterator_tag;
+
+    /**
+     * @brief Signed integral type for iterator difference.
+     */
+    using difference_type = std::ptrdiff_t;
+
+    /**
+     * @brief Pointer type to the value_type.
+     */
+    using pointer = const value_type*;
+
+    /**
+     * @brief Constructs a blocking iterator from a channel reference.
+     *
+     * @param chan Reference to the channel this iterator will write into.
+     */
+    explicit blocking_writer_iterator(Channel& chan) : chan_{chan} {}
+
+    /**
+     * @brief Writes an element into the channel, blocking until space is available.
+     *
+     * @param val The value to be written into the channel.
+     *
+     * @return The iterator itself.
+     */
+    blocking_writer_iterator& operator=(const value_type& val)
+    {
+        chan_.write(val);
+        return *this;
+    }
+
+    /**
+     * @brief Not applicable (handled by operator=).
+     *
+     * @return The iterator itself.
+     */
+    blocking_writer_iterator& operator*() { return *this; }
+
+    /**
+     * @brief Not applicable (handled by operator=).
+     *
+     * @return The iterator itself.
+     */
+    blocking_writer_iterator& operator++() { return *this; }
+
+    /**
+     * @brief Not applicable (handled by operator=).
+     *
+     * @return The iterator itself.
+     */
+    blocking_writer_iterator operator++(int) { return *this; }
+
+   private:
+    Channel& chan_;
+};
+
+/**
+ * @brief Creates a blocking iterator for the given channel.
+ *
+ * @tparam Channel Type of channel being iterated.
+ *
+ * @param chan Reference to the channel this iterator will iterate over.
+ *
+ * @return A blocking iterator for the specified channel.
+ */
+template <typename Channel>
+blocking_writer_iterator<Channel> back_inserter(Channel& chan)
+{
+    return blocking_writer_iterator<Channel>{chan};
+}
 
 }  // namespace msd
 

--- a/include/msd/channel.hpp
+++ b/include/msd/channel.hpp
@@ -210,7 +210,7 @@ class channel {
      *
      * @return A blocking iterator representing the end condition.
      */
-    iterator end() noexcept { return blocking_iterator<channel<T>>{*this}; }
+    iterator end() noexcept { return blocking_iterator<channel<T>>{*this, true}; }
 
     /**
      * Channel cannot be copied or moved.

--- a/include/msd/static_channel.hpp
+++ b/include/msd/static_channel.hpp
@@ -177,7 +177,7 @@ class static_channel {
      *
      * @return A blocking iterator representing the end condition.
      */
-    iterator end() noexcept { return blocking_iterator<static_channel<T, Capacity>>{*this}; }
+    iterator end() noexcept { return blocking_iterator<static_channel<T, Capacity>>{*this, true}; }
 
     /**
      * Channel cannot be copied or moved.

--- a/tests/blocking_iterator_test.cpp
+++ b/tests/blocking_iterator_test.cpp
@@ -18,30 +18,46 @@ TEST(BlockingIteratorTest, Traits)
 TEST(BlockingIteratorTest, Dereference)
 {
     msd::channel<int> channel;
+    channel << 1;
+    channel << 2;
+
     msd::blocking_iterator<msd::channel<int>> it{channel};
 
-    int in = 1;
-    channel << in;
-    in = 2;
-    channel << in;
-
     EXPECT_EQ(1, *it);
+
+    ++it;
     EXPECT_EQ(2, *it);
 }
 
 TEST(BlockingIteratorTest, NotEqualStop)
 {
     msd::channel<int> channel;
-    msd::blocking_iterator<msd::channel<int>> it{channel};
-
     channel.close();
 
+    msd::blocking_iterator<msd::channel<int>> it{channel};
     EXPECT_FALSE(it != it);
+}
+
+TEST(BlockingIteratorTest, NotEqualAtEndAndChannelClosed)
+{
+    msd::channel<int> channel;
+    channel.close();
+
+    msd::blocking_iterator<msd::channel<int>> it_begin{channel};
+    msd::blocking_iterator<msd::channel<int>> it_end{channel, false};
+    EXPECT_FALSE(it_begin != it_end);
 }
 
 TEST(BlockingIteratorTest, NotEqualContinue)
 {
     msd::channel<int> channel;
+    channel << 1;
+
+    msd::blocking_iterator<msd::channel<int>> it{channel};
+
+    EXPECT_FALSE(it != it);
+}
+
     msd::blocking_iterator<msd::channel<int>> it{channel};
 
     channel << 1;

--- a/tests/channel_test.cpp
+++ b/tests/channel_test.cpp
@@ -257,7 +257,7 @@ TEST(ChannelTest, Multithreading)
 
     std::vector<std::thread> threads{};
     for (std::size_t i = 0U; i < kThreadsToReadFrom; ++i) {
-        threads.emplace_back(std::thread{worker});
+        threads.emplace_back(worker);
     }
 
     // Send numbers to channel

--- a/tests/static_channel_test.cpp
+++ b/tests/static_channel_test.cpp
@@ -157,7 +157,7 @@ TEST(StaticChannelTest, Multithreading)
 
     std::vector<std::thread> threads{};
     for (std::size_t i = 0U; i < kThreadsToReadFrom; ++i) {
-        threads.emplace_back(std::thread{worker});
+        threads.emplace_back(worker);
     }
 
     // Send numbers to channel


### PR DESCRIPTION
Fixes #35 by implementing an output iterator.

```c++
std::transform(input_chan.begin(), input_chan.end(), msd::back_inserter(output_chan))
```